### PR TITLE
Fix classname reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and <h1 class='important-topic'>)
 .important-topic
 
 /*
-select all elements that have the 'welcome-message' classname (e.g. <p class='helpful-hint'>
+select all elements that have the 'helpful-hint' classname (e.g. <p class='helpful-hint'>
 and <p class='helpful-hint'>)
 */
 .helpful-hint

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ structure, hierarchy, and meaning &mdash; the "marking-up" of content.
 Questions in the mind of an HTML author are:
 
 * Is it best to list these members' names with numbers, or bullets?
-* Does this menu belong in in the navigation in the header?
+* Does this menu belong in the navigation in the header?
 * Should this additional reference be an aside, or a separate section?
 
 These questions deal with structure, hierarchy, and meaning, which are


### PR DESCRIPTION
Fixed classname reference to match the example on line 128; removed extra "in" on line 41.